### PR TITLE
Add Long-Press (Hold) Support and UI Improvements to Speedtest Plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,12 +77,10 @@ class Speedtest(ActionBase):
 
 
     def event_callback(self, event, data=None):
-        # Handles key events for the Speedtest action
-        if hasattr(Input, "Key") and hasattr(Input.Key, "Events"):
-            if event == Input.Key.Events.SHORT_UP:
-                self.on_key_down()
-            elif event == Input.Key.Events.HOLD_START:
-                self.on_key_hold()
+        if event == Input.Key.Events.SHORT_UP:
+            self.on_key_down()
+        elif event == Input.Key.Events.HOLD_START:
+            self.on_key_hold()
 
     def perform_test(self):
         self.init_speedtest()

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ class Speedtest(ActionBase):
         """
         self.set_top_label(None)
         self.set_center_label(None)
-        self.set_bottom_label(None)
+        self.set_bottom_label("Start")
         self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "speed.png"), size=0.8, valign=-1, update=True)
 
 

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ class Speedtest(ActionBase):
         self.set_top_label(None)
         self.set_center_label(None)
         self.set_bottom_label(None)
+        self.set_media(media_path=os.path.join(self.plugin_base.PATH,
 
     def event_callback(self, event, data=None):
         # Handles key events for the Speedtest action
@@ -117,7 +118,6 @@ class SpeedTestPlugin(PluginBase):
             action_id_suffix="Speedtest",
             action_name=self.lm.get("actions.speedtest.name"),
             icon=Gtk.Picture.new_for_filename(os.path.join(self.PATH, "assets", "speed.png")),
-            #icon=Gtk.Image.new_from_file(os.path.join(self.PATH, "assets", "speed.png")),
             action_support={
                 Input.Key: ActionInputSupport.SUPPORTED,
                 Input.Dial: ActionInputSupport.SUPPORTED,

--- a/main.py
+++ b/main.py
@@ -66,6 +66,21 @@ class Speedtest(ActionBase):
         elif self.image_state in ["running", "error"]:
             return
 
+    def on_key_hold(self):
+        """
+        Clears the top, center, and bottom labels when the button is held down.
+        """
+        self.set_top_label(None)
+        self.set_center_label(None)
+        self.set_bottom_label(None)
+
+    def event_callback(self, event, data=None):
+        # Handles key events for the Speedtest action
+        if hasattr(Input, "Key") and hasattr(Input.Key, "Events"):
+            if event == Input.Key.Events.SHORT_UP:
+                self.on_key_down()
+            elif event == Input.Key.Events.HOLD_START:
+                self.on_key_hold()
 
     def perform_test(self):
         self.init_speedtest()
@@ -78,7 +93,7 @@ class Speedtest(ActionBase):
             # Page has changed while test was running
             return
 
-        self.set_top_label(f"{ping} ms", font_size=11, update=False)
+        self.set_top_label(f"Ping: {ping} ms", font_size=11, update=False)
         self.set_center_label(f"{download} Mbps", font_size=12, update=False)
         self.set_bottom_label(f"{upload} Mbps", font_size=12)
 

--- a/main.py
+++ b/main.py
@@ -116,8 +116,8 @@ class SpeedTestPlugin(PluginBase):
             action_base=Speedtest,
             action_id_suffix="Speedtest",
             action_name=self.lm.get("actions.speedtest.name"),
-            # icon=Gtk.Picture.new_for_filename(os.path.join(self.PATH, "assets", "speed.png")),
-            icon=Gtk.Image.new_from_file(os.path.join(self.PATH, "assets", "speed.png")),
+            icon=Gtk.Picture.new_for_filename(os.path.join(self.PATH, "assets", "speed.png")),
+            #icon=Gtk.Image.new_from_file(os.path.join(self.PATH, "assets", "speed.png")),
             action_support={
                 Input.Key: ActionInputSupport.SUPPORTED,
                 Input.Dial: ActionInputSupport.SUPPORTED,

--- a/main.py
+++ b/main.py
@@ -68,12 +68,13 @@ class Speedtest(ActionBase):
 
     def on_key_hold(self):
         """
-        Clears the top, center, and bottom labels when the button is held down.
+        Clears the top, center, and bottom labels and restores the speed.png image.
         """
         self.set_top_label(None)
         self.set_center_label(None)
         self.set_bottom_label(None)
-        self.set_media(media_path=os.path.join(self.plugin_base.PATH,
+        self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "speed.png"), size=0.8, valign=-1, update=True)
+
 
     def event_callback(self, event, data=None):
         # Handles key events for the Speedtest action

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class Speedtest(ActionBase):
             self.show_error()
             self.set_bottom_label(None)
             self.image_state = "error"
-        
+
     def on_ready(self):
         self.set_media(media_path=os .path.join(self.plugin_base.PATH, "assets", "speed.png"), size=0.8, valign=-1, update=True)
         self.set_bottom_label("Start")
@@ -78,7 +78,7 @@ class Speedtest(ActionBase):
             # Page has changed while test was running
             return
 
-        self.set_top_label(f"Ping: {ping} ms", font_size=11, update=False)
+        self.set_top_label(f"{ping} ms", font_size=11, update=False)
         self.set_center_label(f"{download} Mbps", font_size=12, update=False)
         self.set_bottom_label(f"{upload} Mbps", font_size=12)
 

--- a/main.py
+++ b/main.py
@@ -116,7 +116,8 @@ class SpeedTestPlugin(PluginBase):
             action_base=Speedtest,
             action_id_suffix="Speedtest",
             action_name=self.lm.get("actions.speedtest.name"),
-            icon=Gtk.Picture.new_for_filename(os.path.join(self.PATH, "assets", "speed.png")),
+            # icon=Gtk.Picture.new_for_filename(os.path.join(self.PATH, "assets", "speed.png")),
+            icon=Gtk.Image.new_from_file(os.path.join(self.PATH, "assets", "speed.png")),
             action_support={
                 Input.Key: ActionInputSupport.SUPPORTED,
                 Input.Dial: ActionInputSupport.SUPPORTED,


### PR DESCRIPTION
Overview

This pull request introduces enhancements to the Speedtest plugin, improving its user interaction and UI feedback.

---

### Key Changes

#### 1. **Long-Press (Hold) Support**
- Added an `event_callback` method to the `Speedtest` action class, mirroring the event handling style of other plugins (such as the Counter plugin).
- Implemented an `on_key_hold` method that is triggered on long-press (`HOLD_START` event).
- When the button is held, the plugin now:
  - Clears the top and center labels and resets the bottom label to "Start".
  - Restores the default speedtest image (`speed.png`) to the button, ensuring the UI resets after a test or error.

#### 2. **UI Consistency**
- Ensured that after a speed test or error, holding the button will always restore the original image and clear any test results or error messages from the labels.

#### 3. **Non-breaking Changes**
- The original short-press (`on_key_down`) behavior is preserved and now routed through the new event handling system for consistency with other plugins.